### PR TITLE
Make reposdir setting useful

### DIFF
--- a/attributes/main.rb
+++ b/attributes/main.rb
@@ -79,6 +79,7 @@ default['yum']['main']['password'] = nil #  /.*/
 default['yum']['main']['recent'] = nil # /^\d+$/
 default['yum']['main']['releasever'] = nil #  /.*/
 default['yum']['main']['repo_gpgcheck'] = nil # [TrueClass, FalseClass]
+default['yum']['main']['reposdir'] = nil #  /.*/
 default['yum']['main']['reset_nice'] = nil # [TrueClass, FalseClass]
 default['yum']['main']['rpmverbosity'] = nil # %w{ info critical# emergency error warn debug }
 default['yum']['main']['showdupesfromrepos'] = nil # [TrueClass, FalseClass]

--- a/templates/default/main.erb
+++ b/templates/default/main.erb
@@ -198,6 +198,9 @@ releasever=<%= @config.releasever %>
 <% if @config.repo_gpgcheck %>
 repo_gpgcheck=<%= @config.repo_gpgcheck %>
 <% end %>
+<% if @config.reposdir %>
+reposdir=<%= @config.reposdir %>
+<% end %>
 <% if @config.reset_nice %>
 reset_nice=<%= @config.reset_nice %>
 <% end %>
@@ -251,7 +254,7 @@ username=<%= @config.username %>
 <% end %>
 <% if @config.options -%>
 <%   @config.options.each do |key, value| -%>
-<%= key %>=<%= 
+<%= key %>=<%=
        case value
        when Array
          value.join("\n       ")


### PR DESCRIPTION
The reposdir attribute was added by a recent commit, however it was not used in the globalconfig template, which made it pretty much useless. This adds it to the template and default attributes.