### PR TITLE
ensuring that the yum clean updates comes before the make cache

### DIFF
--- a/providers/repository.rb
+++ b/providers/repository.rb
@@ -46,8 +46,8 @@ action :create  do
     mode new_resource.mode
     variables(:config => new_resource)
     if new_resource.make_cache
-      notifies :run, "execute[yum-makecache-#{new_resource.repositoryid}]", :immediately
       notifies :run, "execute[yum clean #{new_resource.repositoryid}]", :immediately
+      notifies :run, "execute[yum-makecache-#{new_resource.repositoryid}]", :immediately
       notifies :create, "ruby_block[yum-cache-reload-#{new_resource.repositoryid}]", :immediately
     end
   end


### PR DESCRIPTION
check me here, but we have a couple of cases where we've run into:
STDOUT: 
STDERR: Not using downloaded repomd.xml because it is older than what we have:
            Current   : Wed May 27 15:20:59 2015
            Downloaded: Tue May 26 16:44:56 2015
cache seemed out of date...  We found that a yum clean <all> fixed the issue.

Here we ask that the yum clean all happens before the yum makecache