### PR TITLE
Execute clean before makecache

### DIFF
--- a/providers/repository.rb
+++ b/providers/repository.rb
@@ -46,8 +46,8 @@ action :create  do
     mode new_resource.mode
     variables(:config => new_resource)
     if new_resource.make_cache
-      notifies :run, "execute[yum-makecache-#{new_resource.repositoryid}]", :immediately
       notifies :run, "execute[yum clean #{new_resource.repositoryid}]", :immediately
+      notifies :run, "execute[yum-makecache-#{new_resource.repositoryid}]", :immediately
       notifies :create, "ruby_block[yum-cache-reload-#{new_resource.repositoryid}]", :immediately
     end
   end


### PR DESCRIPTION
This addresses #119 and I believe solved some timeout issues we were having on the makecache command which would cause the Chef client run to fail.