### PR TITLE
Accept prompts while fetching repo metadata

### DIFF
--- a/providers/repository.rb
+++ b/providers/repository.rb
@@ -59,7 +59,7 @@ action :create  do
 
   # get the metadata for this repo only
   execute "yum-makecache-#{new_resource.repositoryid}" do
-    command "yum -q makecache --disablerepo=* --enablerepo=#{new_resource.repositoryid}"
+    command "yum -q -y makecache --disablerepo=* --enablerepo=#{new_resource.repositoryid}"
     action :nothing
     only_if { new_resource.enabled }
   end


### PR DESCRIPTION
Associated issue: #124

With the new `repo_gpgcheck` attribute, a signing key can now be involved in fetching the repository metadata. If this is a previously un-imported key, a prompt is generated by `yum makecache` asking whether to import it, which fails in a chef run due to the non-interactive context. This results in the `yum_repository` resource failing if a previously un-imported key is used in tandem with `repo_gpgcheck = true`.

Cookbook users should be responsible for ensuring that keys they refer to in their resources can be trusted, either by referring to keys at secure URLs, or by creating a local, trusted file using managed secrets, and referring directly to that.

Therefore, add the `-y` flag to the `yum makecache` command, allowing repo metadata to be fetched without manual intervention.

Edit: the travis build failure would appear to be unrelated (though I could be wrong)...