### PR TITLE
Add 'deltarpm' true/false configuration

### DIFF
--- a/attributes/main.rb
+++ b/attributes/main.rb
@@ -36,6 +36,7 @@ default['yum']['main']['color_update_installed'] = nil #  /.*/
 default['yum']['main']['color_update_local'] = nil #  /.*/
 default['yum']['main']['color_update_remote'] = nil #  /.*/
 default['yum']['main']['commands'] = nil #  /.*/
+default['yum']['main']['deltarpm'] = nil # [TrueClass, FalseClass]
 default['yum']['main']['debuglevel'] = nil # /^\d+$/
 default['yum']['main']['diskspacecheck'] = nil # [TrueClass, FalseClass]
 default['yum']['main']['enable_group_conditionals'] = nil # [TrueClass, FalseClass]

--- a/resources/globalconfig.rb
+++ b/resources/globalconfig.rb
@@ -44,6 +44,7 @@ attribute :color_update_local, :kind_of => String, :regex => /.*/, :default => n
 attribute :color_update_remote, :kind_of => String, :regex => /.*/, :default => nil
 attribute :commands, :kind_of => String, :regex => /.*/, :default => nil
 attribute :debuglevel, :kind_of => String, :regex => /^\d+$/, :default => '2'
+attribute :deltarpm, :kind_of => [TrueClass, FalseClass], :default => nil
 attribute :diskspacecheck, :kind_of => [TrueClass, FalseClass], :default => nil
 attribute :distroverpkg, :kind_of => String, :regex => /.*/, :default => nil
 attribute :enable_group_conditionals, :kind_of => [TrueClass, FalseClass], :default => nil

--- a/templates/default/main.erb
+++ b/templates/default/main.erb
@@ -65,6 +65,11 @@ commands=<%= @config.commands %>
 <% if @config.debuglevel %>
 debuglevel=<%= @config.debuglevel %>
 <% end %>
+<% if @config.deltarpm == true %>
+deltarpm=1
+<% elsif @config.deltarpm == false %>
+deltarpm=0
+<% end %>
 <% if @config.diskspacecheck %>
 diskspacecheck=<%= @config.diskspacecheck %>
 <% end %>


### PR DESCRIPTION
Adds `deltarpm=0` or `deltarpm=1` to `yum_globalconfig`.

The proposed default is `nil` because, at least on CentOS 7, the directive does not exist by default in `/etc/yum.conf`; it will only be added to a `yum_globalconfig` file if you explicitly say `true` or `false`. Also, having the default as `nil` prevents any errors by default on systems that do not record `deltarpm=` as a valid parameter since you must explicitly add it.

By setting `node['yum']['main']['deltarpm'] = false`, you can prevent the "`Delta RPMs disabled because /usr/bin/applydeltarpm not installed`" warning from CentOS 7 and be more likely to not have any STDERR output on properly configured systems.