### PR TITLE
Replace clean_headers with clean_metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ end
 * `cost` - relative cost of accessing this repository. Useful for
   weighing one repo's packages as greater/less than any other.
   defaults to 1000
-* `clean_headers` - Run "yum clean headers <reponame>" during
+* `clean_metadata` - Run "yum clean metadata <reponame>" during
   repository creation. defaults to true.
 * `description` - Maps to the 'name' parameter in a repository .conf.
   Descriptive name for the repository channel. This directive must be

--- a/providers/repository.rb
+++ b/providers/repository.rb
@@ -36,6 +36,13 @@ action :create do
   # notifies timing to :immediately for the same reasons. Remove both
   # of these when dropping Chef 10 support.
 
+  if new_resource.clean_headers
+    Chef::Log.warn <<-eos
+      Use of `clean_headers` in resource yum[#{new_resource.repositoryid}] is now deprecated and will be removed in a future release.
+      `clean_metadata` should be used instead
+    eos
+  end
+
   template "/etc/yum.repos.d/#{new_resource.repositoryid}.repo" do
     if new_resource.source.nil?
       source 'repo.erb'
@@ -46,14 +53,14 @@ action :create do
     mode new_resource.mode
     variables(config: new_resource)
     if new_resource.make_cache
-      notifies :run, "execute[yum clean headers #{new_resource.repositoryid}]", :immediately if new_resource.clean_headers
+      notifies :run, "execute[yum clean metadata #{new_resource.repositoryid}]", :immediately if new_resource.clean_metadata || new_resource.clean_headers
       notifies :run, "execute[yum-makecache-#{new_resource.repositoryid}]", :immediately
       notifies :create, "ruby_block[yum-cache-reload-#{new_resource.repositoryid}]", :immediately
     end
   end
 
-  execute "yum clean headers #{new_resource.repositoryid}" do
-    command "yum clean headers --disablerepo=* --enablerepo=#{new_resource.repositoryid}"
+  execute "yum clean metadata #{new_resource.repositoryid}" do
+    command "yum clean metadata --disablerepo=* --enablerepo=#{new_resource.repositoryid}"
     action :nothing
   end
 

--- a/resources/repository.rb
+++ b/resources/repository.rb
@@ -25,7 +25,8 @@ default_action :create
 # http://linux.die.net/man/5/yum.conf
 attribute :baseurl, kind_of: String, regex: /.*/, default: nil
 attribute :cost, kind_of: String, regex: /^\d+$/, default: nil
-attribute :clean_headers, kind_of: [TrueClass, FalseClass], default: true
+attribute :clean_headers, kind_of: [TrueClass, FalseClass], default: false # deprecated
+attribute :clean_metadata, kind_of: [TrueClass, FalseClass], default: true
 attribute :description, kind_of: String, regex: /.*/, default: 'Ye Ole Rpm Repo'
 attribute :enabled, kind_of: [TrueClass, FalseClass], default: true
 attribute :enablegroups, kind_of: [TrueClass, FalseClass], default: nil

--- a/spec/unit/test_repository_eight_spec.rb
+++ b/spec/unit/test_repository_eight_spec.rb
@@ -41,10 +41,10 @@ Have a nice day.
         .with_content(test_repository_eight_content)
     end
 
-    it 'steps into yum_repository and runs execute[yum clean headers test8]' do
-      expect(test_repository_eight_run).to_not run_execute('yum clean headers test8')
+    it 'steps into yum_repository and runs execute[yum clean metadata test8]' do
+      expect(test_repository_eight_run).to_not run_execute('yum clean metadata test8')
         .with(
-          command: 'yum clean headers --disablerepo=* --enablerepo=test8'
+          command: 'yum clean metadata --disablerepo=* --enablerepo=test8'
         )
     end
 

--- a/spec/unit/test_repository_nine_spec.rb
+++ b/spec/unit/test_repository_nine_spec.rb
@@ -42,10 +42,10 @@ Have a nice day.
         .with_content(test_repository_nine_content)
     end
 
-    it 'steps into yum_repository and runs execute[yum clean headers test9]' do
-      expect(test_repository_nine_run).to_not run_execute('yum clean headers test9')
+    it 'steps into yum_repository and runs execute[yum clean metadata test9]' do
+      expect(test_repository_nine_run).to_not run_execute('yum clean metadata test9')
         .with(
-          command: 'yum clean headers --disablerepo=* --enablerepo=test9'
+          command: 'yum clean metadata --disablerepo=* --enablerepo=test9'
         )
     end
 

--- a/spec/unit/test_repository_one_spec.rb
+++ b/spec/unit/test_repository_one_spec.rb
@@ -36,8 +36,8 @@ gpgcheck=1
       expect(test_repository_one_run).to render_file('/etc/yum.repos.d/test1.repo').with_content(test_repository_one_content)
     end
 
-    it 'steps into yum_repository and runs execute[yum clean headers test1]' do
-      expect(test_repository_one_run).to_not run_execute('yum clean headers test1')
+    it 'steps into yum_repository and runs execute[yum clean metadata test1]' do
+      expect(test_repository_one_run).to_not run_execute('yum clean metadata test1')
     end
 
     it 'steps into yum_repository and runs execute[yum-makecache-test1]' do

--- a/spec/unit/test_repository_seven_spec.rb
+++ b/spec/unit/test_repository_seven_spec.rb
@@ -37,8 +37,8 @@ gpgkey=http://example.com/RPM-GPG-KEY-FOOBAR-1
       expect(test_repository_seven_run).to render_file('/etc/yum.repos.d/test7.repo').with_content(test_repository_seven_content)
     end
 
-    it 'steps into yum_repository and runs execute[yum clean headers test7]' do
-      expect(test_repository_seven_run).to_not run_execute('yum clean headers test7')
+    it 'steps into yum_repository and runs execute[yum clean metadata test7]' do
+      expect(test_repository_seven_run).to_not run_execute('yum clean metadata test7')
     end
 
     it 'steps into yum_repository and runs execute[yum-makecache-test7]' do

--- a/spec/unit/test_repository_six_spec.rb
+++ b/spec/unit/test_repository_six_spec.rb
@@ -36,8 +36,8 @@ gpgcheck=1
       expect(test_repository_six_run).to render_file('/etc/yum.repos.d/test6.repo').with_content(test_repository_six_content)
     end
 
-    it 'steps into yum_repository and runs execute[yum clean headers test6]' do
-      expect(test_repository_six_run).to_not run_execute('yum clean headers test6')
+    it 'steps into yum_repository and runs execute[yum clean metadata test6]' do
+      expect(test_repository_six_run).to_not run_execute('yum clean metadata test6')
     end
 
     it 'steps into yum_repository and runs execute[yum-makecache-test6]' do

--- a/spec/unit/test_repository_three_spec.rb
+++ b/spec/unit/test_repository_three_spec.rb
@@ -36,8 +36,8 @@ gpgcheck=1
       expect(test_repository_three_run).to render_file('/etc/yum.repos.d/test3.repo').with_content(test_repository_three_content)
     end
 
-    it 'steps into yum_repository and runs execute[yum clean headers test3]' do
-      expect(test_repository_three_run).to_not run_execute('yum clean headers test3')
+    it 'steps into yum_repository and runs execute[yum clean metadata test3]' do
+      expect(test_repository_three_run).to_not run_execute('yum clean metadata test3')
     end
 
     it 'steps into yum_repository and runs execute[yum-makecache-test3]' do

--- a/spec/unit/test_repository_two_spec.rb
+++ b/spec/unit/test_repository_two_spec.rb
@@ -62,8 +62,8 @@ timeout=10
       expect(test_repository_two_run).to render_file('/etc/yum.repos.d/unit-test-2.repo').with_content(test_repository_two_content)
     end
 
-    it 'steps into yum_repository and runs execute[yum clean headers unit-test2]' do
-      expect(test_repository_two_run).to_not run_execute('yum clean headers unit-test-2')
+    it 'steps into yum_repository and runs execute[yum clean metadata unit-test2]' do
+      expect(test_repository_two_run).to_not run_execute('yum clean metadata unit-test-2')
     end
 
     it 'steps into yum_repository and runs execute[yum-makecache-unit-test-2]' do


### PR DESCRIPTION
It turned out YUM deprecated clean headers, and instead clean metadata should be used.
This also affects DNF's yum compatibility mode, where it had removed the 'headers' option