### PR TITLE
dnf compat at compile time + other updates

### DIFF
--- a/.kitchen.docker.yml
+++ b/.kitchen.docker.yml
@@ -1,6 +1,7 @@
 driver:
   name: dokken
-  chef_version: 12.6.0
+  chef_version: latest
+  privileged: true # because Docker and SystemD/Upstart
 
 transport:
   name: dokken
@@ -25,9 +26,9 @@ platforms:
   driver:
     image: centos:7
 
-- name: fedora-22
+- name: fedora-23
   driver:
-    image: fedora:22
+    image: fedora:23
 
 suites:
   - name: default
@@ -38,4 +39,4 @@ suites:
     run_list:
       - recipe[yum::dnf_yum_compat]
       - recipe[yum_test::test_dnf_compat]
-    includes: fedora-22
+    includes: fedora-23

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -8,7 +8,7 @@ platforms:
   - name: centos-5.11
   - name: centos-6.7
   - name: centos-7.2
-  - name: fedora-22
+  - name: fedora-23
 
 suites:
   - name: default
@@ -19,4 +19,4 @@ suites:
     run_list:
       - recipe[yum::dnf_yum_compat]
       - recipe[yum_test::test_dnf_compat]
-    includes: fedora-22
+    includes: fedora-23

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 sudo: required
+dist: trusty
 
 # install the pre-release chef-dk.  Use chef-stable-precise to install the stable release
 addons:
@@ -8,6 +9,8 @@ addons:
     packages:
       - chefdk
 
+install: echo "skip bundle install"
+
 services: docker
 
 env:
@@ -15,25 +18,20 @@ env:
   - INSTANCE=default-centos-5
   - INSTANCE=default-centos-6
   - INSTANCE=default-centos-7
-  - INSTANCE=default-fedora-22
-  - INSTANCE=dnf-compat-fedora-22
+  - INSTANCE=default-fedora-23
+  - INSTANCE=dnf-compat-fedora-23
 
-# Don't `bundle install`
-install: echo "skip bundle install"
+  fast_finish: true
 
-# Ensure we make ChefDK's Ruby the default
 before_script:
-  # https://github.com/zuazo/kitchen-in-travis-native/issues/1#issuecomment-142230889
-  - docker version
-  - docker info
-  - mount
   - sudo iptables -L DOCKER || ( echo "DOCKER iptables chain missing" ; sudo iptables -N DOCKER )
   - eval "$(/opt/chefdk/bin/chef shell-init bash)"
   - /opt/chefdk/embedded/bin/chef gem install kitchen-dokken
+
 script:
   - /opt/chefdk/embedded/bin/chef --version
-  - /opt/chefdk/embedded/bin/rubocop --version
-  - /opt/chefdk/embedded/bin/rubocop
+  - /opt/chefdk/embedded/bin/cookstyle --version
+  - /opt/chefdk/embedded/bin/cookstyle
   - /opt/chefdk/embedded/bin/foodcritic --version
   - /opt/chefdk/embedded/bin/foodcritic . --exclude spec -f any
   - /opt/chefdk/embedded/bin/rspec

--- a/Gemfile
+++ b/Gemfile
@@ -1,28 +1,13 @@
 source 'https://rubygems.org'
 
-group :rake do
-  gem 'rake'
-  gem 'tomlrb'
-end
-
-group :lint do
-  gem 'foodcritic', '~> 6.0'
-  gem 'rubocop', '~> 0.38'
-end
-
-group :unit do
-  gem 'berkshelf', '~> 4.3'
-  gem 'chefspec', '~> 4.6'
-end
-
-group :kitchen_common do
-  gem 'test-kitchen', '~> 1.6'
-end
-
-group :kitchen_vagrant do
-  gem 'kitchen-vagrant', '~> 0.19'
-end
-
-group :kitchen_inspec do
-  gem 'kitchen-inspec'
-end
+gem 'berkshelf', '~> 4.3'
+gem 'chefspec', '~> 4.6'
+gem 'cookstyle'
+gem 'foodcritic', '~> 6.2'
+gem 'kitchen-dokken'
+gem 'kitchen-inspec', '~> 0.12'
+gem 'kitchen-vagrant', '~> 0.20'
+gem 'rake'
+gem 'stove'
+gem 'test-kitchen', '~> 1.7'
+gem 'tomlrb'

--- a/MAINTAINERS.toml
+++ b/MAINTAINERS.toml
@@ -19,7 +19,7 @@ for details on the process and how to become a maintainer or the project lead.
     [Org.Components.Core]
       title = "Project Maintainer"
 
-      lieutenant = 'someara'
+      lieutenant = 'tas50'
     
       maintainers = [
         'sigje',

--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,5 @@
 require 'rspec/core/rake_task'
+require 'cookstyle'
 require 'rubocop/rake_task'
 require 'foodcritic'
 require 'kitchen'

--- a/libraries/matchers.rb
+++ b/libraries/matchers.rb
@@ -1,5 +1,3 @@
-# Matchers for chefspec 3
-
 if defined?(ChefSpec)
   def create_yum_repository(resource_name)
     ChefSpec::Matchers::ResourceMatcher.new(:yum_repository, :create, resource_name)

--- a/providers/globalconfig.rb
+++ b/providers/globalconfig.rb
@@ -3,7 +3,7 @@
 # Provider:: repository
 #
 # Author:: Sean OMeara <someara@chef.io>
-# Copyright 2013, Chef
+# Copyright 2013-2016, Chef Software, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/providers/repository.rb
+++ b/providers/repository.rb
@@ -3,7 +3,7 @@
 # Provider:: repository
 #
 # Author:: Sean OMeara <someara@chef.io>
-# Copyright 2013, Chef
+# Copyright 2013-2016, Chef Software, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -3,7 +3,7 @@
 # Author:: Joshua Timberman (<joshua@chef.io>)
 # Recipe:: yum::default
 #
-# Copyright 2013-2014, Chef Software, Inc (<legal@chef.io>)
+# Copyright 2013-2016, Chef Software, Inc (<legal@chef.io>)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/dnf_yum_compat.rb
+++ b/recipes/dnf_yum_compat.rb
@@ -2,7 +2,7 @@
 # Author:: Tim Smith (<tsmith@chef.io>)
 # Recipe:: yum::fedora_yum_compat
 #
-# Copyright 2015, Chef Software, Inc (<legal@chef.io>)
+# Copyright 2015-2016, Chef Software, Inc (<legal@chef.io>)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,5 +19,5 @@
 execute 'install yum' do
   command 'dnf install yum -y'
   not_if { ::File.exist?('/var/lib/yum') }
-  action :run
-end
+  action :nothing
+end.run_action(:run)

--- a/resources/globalconfig.rb
+++ b/resources/globalconfig.rb
@@ -3,7 +3,7 @@
 # Resource:: repository
 #
 # Author:: Sean OMeara <someara@chef.io>
-# Copyright 2013, Chef
+# Copyright 2013-2016, Chef Software, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/resources/repository.rb
+++ b/resources/repository.rb
@@ -3,7 +3,7 @@
 # Resource:: repository
 #
 # Author:: Sean OMeara <someara@chef.io>
-# Copyright 2013, Chef
+# Copyright 2013-2016, Chef Software, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/fixtures/cookbooks/yum_test/recipes/test_dnf_compat.rb
+++ b/test/fixtures/cookbooks/yum_test/recipes/test_dnf_compat.rb
@@ -1,1 +1,1 @@
-package 'vim'
+package 'which'


### PR DESCRIPTION
### Description

This allows us to use cookbooks like build-essential to run at compile time while still getting dnf installed on the system

### Issues Resolved

[List any existing issues this PR resolves]

### Check List
- [ ] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD


Convert to cookstyle
Update deps
Use the latest in kitchen dokken
Test on Fedora 23 not 22

Signed-off-by: Tim Smith <tsmith@chef.io>