### PR TITLE
Change EPEL yum_repository ex. to use hypothetical Our Co.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,11 +32,11 @@ yum_repository 'zenoss' do
   action :create
 end
 
-# add the EPEL repo
-yum_repository 'epel' do
-  description 'Extra Packages for Enterprise Linux'
-  mirrorlist 'http://mirrors.fedoraproject.org/mirrorlist?repo=epel-6&arch=$basearch'
-  gpgkey 'http://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-6'
+# add some internal company repo
+yum_repository 'OurCo' do
+  description 'OurCo yum repository'
+  mirrorlist 'http://artifacts.ourco.org/mirrorlist?repo=ourco-6&arch=$basearch'
+  gpgkey 'http://artifacts.ourco.org/pub/yum/RPM-GPG-KEY-OURCO-6'
   action :create
 end
 ```


### PR DESCRIPTION
### Description

Clarifies new behavior: Not to use yum_repository to define an EPEL one, but to use yum-epel CB for that.

### Issues Resolved

#153 

### Check List
- [X] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
- [X] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD


Fixes #153

Using yum_repository to define a repo for EPEL is misleading as
users should be using the yum-epel cookbook for that. Here we
redo the example to be a hypothetical company instead.