### PR TITLE
fixing baseurl to support multiple urls as per documentation

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -20,3 +20,7 @@ suites:
       - recipe[yum::dnf_yum_compat]
       - recipe[yum_test::test_dnf_compat]
     includes: fedora-23
+  - name: global_conflig
+    run_list:
+      - recipe[yum::default]
+      - recipe[yum_test::test_globalconfig_two]

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ dist: trusty
 addons:
   apt:
     sources:
-      - chef-stable-trusty
+      - chef-current-trusty
     packages:
       - chefdk
 

--- a/resources/repository.rb
+++ b/resources/repository.rb
@@ -23,7 +23,7 @@ actions :create, :delete, :add, :remove, :makecache
 default_action :create
 
 # http://linux.die.net/man/5/yum.conf
-attribute :baseurl, kind_of: String, regex: /.*/, default: nil
+attribute :baseurl, kind_of: [String, Array], regex: /.*/, default: nil
 attribute :cost, kind_of: String, regex: /^\d+$/, default: nil
 attribute :clean_headers, kind_of: [TrueClass, FalseClass], default: false # deprecated
 attribute :clean_metadata, kind_of: [TrueClass, FalseClass], default: true

--- a/templates/default/repo.erb
+++ b/templates/default/repo.erb
@@ -6,7 +6,7 @@ name=<%= @config.description %>
 <% if @config.baseurl %>
 baseurl=<%= case @config.baseurl
      when Array
-       @config.baseurl.join("\n       ")
+       @config.baseurl.join("\n")
      else
        @config.baseurl
      end %>

--- a/templates/default/repo.erb
+++ b/templates/default/repo.erb
@@ -4,8 +4,13 @@
 [<%= @config.repositoryid %>]
 name=<%= @config.description %>
 <% if @config.baseurl %>
-baseurl=<%= @config.baseurl %>
-<% end %>
+baseurl=<%= case @config.baseurl
+     when Array
+       @config.baseurl.join("\n       ")
+     else
+       @config.baseurl
+     end %>
+<% end -%>
 <% if @config.cost %>
 cost=<%= @config.cost %>
 <% end %>


### PR DESCRIPTION
### Description

Update baseurl attribute to be of type String, Array 
Update template for repo to iterate through the baseurl attribute if it's an array

Yum configuration expects that baseurl can be multiple urls just as the GPG key is as per http://linux.die.net/man/5/yum.conf.

### Issues Resolved

Issue #155 

### Check List
- [ ] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD


