### PR TITLE
Update metadata.rb

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -9,7 +9,7 @@ version '4.0.0'
   supports os
 end
 
-source_url 'https://github.com/chef-cookbooks/yum'
-issues_url 'https://github.com/chef-cookbooks/yum/issues'
+source_url 'https://github.com/chef-cookbooks/yum' if respond_to?(:source_url)
+issues_url 'https://github.com/chef-cookbooks/yum/issues' if respond_to?(:issues_url)
 
-chef_version '>= 12'
+chef_version '>= 12' if respond_to?(:chef_version)


### PR DESCRIPTION
### Description

Support all versions of chef-client (11 and 12)
chef_version has been introduced during the chef 12 life.  
### Issues Resolved

berks update can failed with chef-client version 12.3.3 and chef-client 11

Avoid issue if you don't have the last chef-client 
chef_version is not supported by all chef 12 version (need to update the working desktop) 
Without the fix the berks update can failed (chef-client version 11 or 12.3.3 for exemple)
