### PR TITLE
Fix `fastestmirror_enabled`.

### DIFF
--- a/templates/default/repo.erb
+++ b/templates/default/repo.erb
@@ -29,7 +29,9 @@ exclude=<%= @config.exclude %>
 failovermethod=<%= @config.failovermethod %>
 <% end %>
 <% if @config.fastestmirror_enabled %>
-fastestmirror_enabled=<%= @config.fastestmirror_enabled %>
+fastestmirror_enabled=1
+<% else %>
+fastestmirror_enabled=0
 <% end %>
 <% if @config.gpgcheck %>
 gpgcheck=1


### PR DESCRIPTION
`fastestmirror_enabled` is a boolean, but is treated in the template as a string.  As a result, the flag can never be set to false/0.
