### PR TITLE
Use an empty string `releasever` to lock an Amazon Linux AMI to its c…

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,10 +76,16 @@ default['yum']['main']['installonlypkgs'] = nil
 default['yum']['main']['installroot'] = nil
 ```
 
-For Amazon platform nodes,
+For Amazon platform nodes, the default is to receive a continuous flow of updates,
 
 ```ruby
 default['yum']['main']['releasever'] = 'latest'
+```
+
+To lock existing instances to the current version of the Amazon AMI,
+
+```ruby
+default['yum']['main']['releasever'] = ''
 ```
 
 ## Related Cookbooks

--- a/templates/main.erb
+++ b/templates/main.erb
@@ -199,7 +199,7 @@ proxy_username=<%= @config.proxy_username %>
 <% if @config.recent %>
 recent=<%= @config.recent %>
 <% end %>
-<% if @config.releasever %>
+<% if @config.releasever && @config.releasever.length > 0 %>
 releasever=<%= @config.releasever %>
 <% end %>
 <% if @config.repo_gpgcheck %>


### PR DESCRIPTION
A proposed fix for #175 