### PR TITLE
Adding proper distroverpkg assignment for Oracle Linux

### DIFF
--- a/attributes/main.rb
+++ b/attributes/main.rb
@@ -1,7 +1,6 @@
 # http://man7.org/linux/man-pages/man5/yum.conf.5.html
 
 default['yum']['main']['cachedir'] = '/var/cache/yum/$basearch/$releasever'
-
 default['yum']['main']['distroverpkg'] = case node['platform']
                                          when 'amazon'
                                            'system-release'

--- a/attributes/main.rb
+++ b/attributes/main.rb
@@ -9,6 +9,8 @@ default['yum']['main']['distroverpkg'] = case node['platform']
                                            'sl-release'
                                          when 'redhat'
                                            nil
+                                         when 'oracle'
+                                           'oraclelinux-release'
                                          else
                                            "#{node['platform']}-release"
                                          end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

### Description
This PR adds an additional option to the distroverpkg attribute assignment case statement to correctly reference the Oracle Linux system version package name. 

### Issues Resolved
On Oracle Linux servers without the additional switch of OL the case statement will result in the distroverpkg attribute being assigned the value "oracle-linux" which is not the proper name for the system release rpm. The correct name for that rpm is "oraclelinux-release". With the incorrect attribute assignment any yum repository file that depends on the $releasever variable will reference malformed URLs since $releasever will not be properly set.

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>